### PR TITLE
Pull Request: Fix Incorrect Asr Calculation Initialization

### DIFF
--- a/lib/src/prayer_time_base.dart
+++ b/lib/src/prayer_time_base.dart
@@ -25,9 +25,9 @@ class PrayTime {
   double _JDate = 0.0;
   int _numIterations = 1;
 
-  PrayTime({int method = Karachi}) {
+  PrayTime({int method = Karachi, in juristic = Shafii}) {
     _calcMethod = method;
-    _asrJuristic = method;
+    _asrJuristic = juristic;
   }
 
   List<String> getPrayerTimes(Map<String, int> date, double latitude,

--- a/lib/src/prayer_time_base.dart
+++ b/lib/src/prayer_time_base.dart
@@ -25,7 +25,7 @@ class PrayTime {
   double _JDate = 0.0;
   int _numIterations = 1;
 
-  PrayTime({int method = Karachi, in juristic = Shafii}) {
+  PrayTime({int method = Karachi, int juristic = Shafii}) {
     _calcMethod = method;
     _asrJuristic = juristic;
   }


### PR DESCRIPTION
**Fix Issue:** Incorrect Asr Calculation for Non-Jafari/Karachi Methods #7

## Overview
This pull request addresses the bug where the Asr calculation is inaccurately determined when initializing `PrayTime` with a method other than `Jafari` or `Karachi`. The root cause was that the `_asrJuristic` property was being incorrectly set to the method value, leading to invalid juristic options during Asr time calculation.

## Changes Made
- **Constructor Update:** Modified the `PrayTime` constructor to accept an additional optional parameter `juristic` with a default value of `Shafii`. This change separates the calculation method (`_calcMethod`) from the Asr juristic method (`_asrJuristic`).
  
  **Before:**
  ```dart
  PrayTime({int method = Karachi}) {
    _calcMethod = method;
    _asrJuristic = method;
  }
  ```
  
  **After:**
  ```dart
  PrayTime({int method = Karachi, int juristic = Shafii}) {
    _calcMethod = method;
    _asrJuristic = juristic;
  }
  ```

## Impact
- **Accuracy:** Ensures that the Asr time is computed accurately using valid juristic options (`Shafii` or `Hanafi`), regardless of the chosen calculation method.
- **Flexibility:** Allows users to explicitly choose the juristic method independently of the calculation method.

## Testing
- Verified that initializing `PrayTime` with methods such as `MWL`, `Egypt`, etc., now correctly applies the default juristic option (`Shafii`) unless explicitly specified.
- Tested both `getPrayerTimes` and `getDatePrayerTimes` to ensure consistent behavior across all prayer time computations.

Please review the changes and let me know if any further adjustments are required.

Thank you!